### PR TITLE
Clean up stdout to be less verbose when no resets need to occur

### DIFF
--- a/go-pin.sh
+++ b/go-pin.sh
@@ -72,7 +72,7 @@ function reset_git() {
   $CD
   if [ $(git rev-parse HEAD) != "$HASH" ]; then
       CHK="git checkout -q $HASH"
-      echo "($REPO) $CHK"
+      echo "Resetting to $HASH"
       $CHK || (git fetch && $CHK)
   fi
 }
@@ -123,8 +123,6 @@ function reset() {
           exit 1
           ;;
       esac
-      echo ----------------------------------
-      echo
     done
 }
 


### PR DESCRIPTION
Minor change but cleans up the output when calling from a build script when no actual reset needs to occur
