### PR TITLE
Use a tag for the revspec when it exists.

### DIFF
--- a/go-pin.sh
+++ b/go-pin.sh
@@ -8,7 +8,10 @@ function freeze_git() {
   find . -type d -iname ".git" | sort | while read repo; do
     cd "$ROOT"
     cd "$repo/.."
-    REV=$(git rev-parse HEAD)
+    REV=$(git tag --points-at HEAD | head -n 1)
+    if [ "$REV" = "" ]; then
+      REV=$(git rev-parse HEAD)
+    fi
     URI=$(git config --get remote.origin.url)
     IMPORT=$(echo $repo | cut -c3- | rev | cut -c6- | rev)
     echo "git $REV $IMPORT $URI"


### PR DESCRIPTION
Rationale: many go libraries pin version numbers. When reading your
dependencies file on a commit diff, it's easier to see if a dependency
updated to a newer version if it went from v1.1 to v1.2 versus some
indistinguishable hash.
